### PR TITLE
fix: migrate 'semver' module to std

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -4,4 +4,4 @@ export { Status } from "https://deno.land/std@0.94.0/http/http_status.ts";
 export {
   gt as SemverGT,
   valid as SemverValid,
-} from "https://deno.land/x/semver/mod.ts";
+} from "https://deno.land/std/semver/mod.ts";


### PR DESCRIPTION
The 'semver' module has been migrated to the standard library https://deno.land/std/semver